### PR TITLE
[VC-65] Implement method to retrieve user operation receipt

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,6 +19,7 @@ type jsonrpcMessage struct {
 
 type jsonrpcErrorMessage struct {
 	Code    int    `json:"code,omitempty"`
+	Data    string `json:"data,omitempty"`
 	Message string `json:"message,omitempty"`
 }
 
@@ -84,6 +85,18 @@ func (b BundlerAPIClient) EstimateUserOperationGas(ctx context.Context, blockcha
 	}
 
 	return preVerificationGas, verificationGas, callGasLimit, nil
+}
+
+func (b BundlerAPIClient) GetUserOperationReceipt(ctx context.Context, blockchain Blockchain,
+	userOpHash string) (out GetUserOperationReceiptResponse, err error) {
+	params := []any{userOpHash}
+
+	response, err := b.doJSONRPCRequest(ctx, blockchain, "eth_getUserOperationReceipt", params)
+	if err != nil {
+		return out, err
+	}
+
+	return out, json.Unmarshal(response.Result, &out)
 }
 
 func (b BundlerAPIClient) doJSONRPCRequest(ctx context.Context, blockchain Blockchain, method string,

--- a/response.go
+++ b/response.go
@@ -1,0 +1,38 @@
+package voltasdk
+
+type Log struct {
+	Address          string   `json:"address"`
+	Topics           []string `json:"topics"`
+	Data             string   `json:"data"`
+	BlockNumber      string   `json:"blockNumber"`
+	TransactionHash  string   `json:"transactionHash"`
+	TransactionIndex string   `json:"transactionIndex"`
+	BlockHash        string   `json:"blockHash"`
+	LogIndex         string   `json:"logIndex"`
+	Removed          bool     `json:"removed"`
+}
+type Receipt struct {
+	BlockHash         string `json:"blockHash"`
+	BlockNumber       string `json:"blockNumber"`
+	From              string `json:"from"`
+	CumulativeGasUsed string `json:"cumulativeGasUsed"`
+	GasUsed           string `json:"gasUsed"`
+	LogsBloom         string `json:"logsBloom"`
+	TransactionHash   string `json:"transactionHash"`
+	TransactionIndex  string `json:"transactionIndex"`
+	EffectiveGasPrice string `json:"effectiveGasPrice"`
+	Logs              []Log  `json:"logs"`
+}
+
+type GetUserOperationReceiptResponse struct {
+	UserOpHash    string  `json:"userOpHash"`
+	Sender        string  `json:"sender"`
+	Paymaster     string  `json:"paymaster"`
+	Nonce         string  `json:"nonce"`
+	Success       bool    `json:"success"`
+	ActualGasCost string  `json:"actualGasCost"`
+	ActualGasUsed string  `json:"actualGasUsed"`
+	From          string  `json:"from"`
+	Receipt       Receipt `json:"receipt"`
+	Logs          []Log   `json:"logs"`
+}

--- a/userop.go
+++ b/userop.go
@@ -45,7 +45,7 @@ type UserOperation struct {
 	PreVerificationGas   *big.Int `json:"preVerificationGas,omitempty"`   // Gas allocated for other overhead in handleOps (and fee paid to bundler?)
 	MaxFeePerGas         *big.Int `json:"maxFeePerGas,omitempty"`
 	MaxPriorityFeePerGas *big.Int `json:"maxPriorityFeePerGas,omitempty"`
-	PaymasterAndData     string   `json:"paymasterAndDataa,omitempty"`
+	PaymasterAndData     string   `json:"paymasterAndData,omitempty"`
 	Signature            string   `json:"signature,omitempty"`
 	// These fields are not serialized in the UserOp, but are used to generate the UserOpHash.
 	EntryPointAddress string     `json:"-"`


### PR DESCRIPTION
As requirement, we are expanding the functionality of our bundler service client. This PR introduces a new method within the API client, allowing us to retrieve a user operation receipt based on the user operation hash.

Changes:
- Enables easier retrieval of user operation receipts for auditing and verification.
- Implemented the logic to fetch user operation receipts using the provided user operation hash.