### PR TITLE
[VC-65] Fix sign signature

### DIFF
--- a/userop.go
+++ b/userop.go
@@ -101,7 +101,7 @@ func (op *UserOperation) packForSignature() ([]byte, error) {
 		{Name: "hashPaymasterAndData", Type: bytes32},
 	}
 	return args.Pack(
-		op.Sender,
+		common.HexToAddress(op.Sender),
 		op.Nonce,
 		crypto.Keccak256Hash(hexutil.MustDecode(op.InitCode)),
 		crypto.Keccak256Hash(hexutil.MustDecode(op.CallData)),


### PR DESCRIPTION
This PR addresses a issue related to user operation signatures. I've identified and resolved the problem causing incorrect signatures during user operations.

Changes:
- Hex sender value to address